### PR TITLE
Add documentation/examples for unhooking inaccessible-object.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Do not activate on a live site!**
 
-It's 2014 and somehow, somewhere something is preventing your site from displaying. You've identified the offending code as none other than a function calling the dreaded `hookex_die()`. You can't deactivate the plugin and can't hack its code lest your fix be wiped out in a future plugin update. The only feasible option to save your site is to wield the [Plugin Hook API](http://codex.wordpress.org/Plugin_API/Hooks)...
+It's ~~2014~~ 215 and somehow, somewhere something is preventing your site from displaying. You've identified the offending code as none other than a function calling the dreaded `hookex_die()`. You can't deactivate the plugin and can't hack its code lest your fix be wiped out in a future plugin update. The only feasible option to save your site is to wield the [Plugin Hook API](http://codex.wordpress.org/Plugin_API/Hooks)...
 
 Cheesiness aside, this plugin can be used as an educational exercise or reference for removing actions that have been attached using various common patterns in WordPress plugins.
 

--- a/examples/closure.php
+++ b/examples/closure.php
@@ -7,6 +7,13 @@
  *
  * Note the disadvantages to using closures in this article:
  * @link http://wprealm.com/blog/using-php-closures-in-wordpress/
+ *
+ * Technically, it IS possible to remove a closure hook callback,
+ * but if more than one closure act on the same filter at the same
+ * priority you have to make a choice, remove them all, or remove
+ * only one (without knowing exactly which)
+ *
+ * @link http://wordpress.stackexchange.com/a/140989
  */
 add_action( 'init', function() {
 	hookex_die();

--- a/examples/inaccessible-object.php
+++ b/examples/inaccessible-object.php
@@ -15,16 +15,19 @@ class Hookex_Inaccessible_Object {
 	}
 }
 
-// Notice that the object is instantiated, but it isn't assigned to a variable.
-// This means there isn't a reference to manipulate the object, so actions and
-// filters cannot be removed.
+/*
+ * Notice that the object is instantiated, but it isn't assigned to a variable.
+ * This makes it MUCH more complicated to unhook the actions and filter callbacks.
+ */
 new Hookex_Inaccessible_Object();
 
-// Recommended approaches:
-
-// If the object is instantiated in a plugin's main scope, it is essentially in
-// the global scope and can be accessed later.
-// $object = new Hookex_Inaccessible_Object();
-
-// Another option is to store the object reference in the global scope explicitly.
-// $GLOBALS['object'] = new Hookex_Inaccessible_Object();
+/*
+ * Recommended approaches:
+ *
+ * If the object is instantiated in a plugin's main scope, it is essentially in
+ * the global scope and can be accessed later.
+ * $object = new Hookex_Inaccessible_Object();
+ *
+ * Another option is to store the object reference in the global scope explicitly.
+ * $GLOBALS['object'] = new Hookex_Inaccessible_Object();
+ */

--- a/examples/object.php
+++ b/examples/object.php
@@ -14,8 +14,10 @@ class Hookex_Object {
 	}
 }
 
-// Plugins are generally loaded in the global scope, however, in some cases they
-// may be loaded within a particular function or method's scope, so it's a good
-// idea to explicitly assign the main plugin object instance to a global
-// variable if you want it to be accessible elsewhere.
+/*
+ * Plugins are generally loaded in the global scope, however, in some cases they
+ * may be loaded within a particular function or method's scope, so it's a good
+ * idea to explicitly assign the main plugin object instance to a global
+ * variable if you want it to be accessible elsewhere.
+ */
 $GLOBALS['hookex_object'] = new Hookex_Object();

--- a/examples/singleton.php
+++ b/examples/singleton.php
@@ -26,6 +26,8 @@ class Hookex_Singleton {
 	}
 }
 
-// This can be called anywhere to retrieve the instance of the object without
-// worrying about hooks being attached multiple times.
+/*
+ * This can be called anywhere to retrieve the instance of the object without
+ * worrying about hooks being attached multiple times.
+ */
 Hookex_Singleton::get_instance();

--- a/examples/static-class.php
+++ b/examples/static-class.php
@@ -20,8 +20,10 @@ class Hookex_Static_Class {
 	}
 }
 
-// Using array syntax with the class name to attach a method.
-// An instance of a static class isn't needed to add or remove hooks, just the name.
+/*
+ * Using array syntax with the class name to attach a method.
+ * An instance of a static class isn't needed to add or remove hooks, just the name.
+ */
 add_action( 'init', array( 'Hookex_Static_Class', 'init1' ) );
 
 // An alternative for setting up a group of hooks.

--- a/remove-hooks.php
+++ b/remove-hooks.php
@@ -3,27 +3,37 @@
  * Demonstrate how the actions can be removed for each example.
  */
 
-// Procedural
-// removes examples/procedural.php
+/*
+ * Procedural
+ * removes examples/procedural.php
+ */
 remove_action( 'init', 'hookex_init' );
 
-// Instantiated object
-// removes examples/object.php
+/*
+ * Instantiated object
+ * removes examples/object.php
+ */
 global $hookex_object; // Declare global just to be safe or use in a different scope.
 remove_action( 'init', array( $hookex_object, 'init' ) );
 
-// Singleton
-// removes examples/singleton.php
+/*
+ * Singleton
+ * removes examples/singleton.php
+ */
 $singleton = Hookex_Singleton::get_instance();
 remove_action( 'init', array( $singleton, 'init' ) );
 
-// Static class
-// removes examples/static-class.php
+/*
+ * Static class
+ * removes examples/static-class.php
+ */
 remove_action( 'init', array( 'Hookex_Static_Class', 'init1' ) );
 remove_action( 'init', array( 'Hookex_Static_Class', 'init2' ) );
 
-// Mixed class
-// removes examples/mixed-class.php
+/*
+ * Mixed class
+ * removes examples/mixed-class.php
+ */
 global $hookex_mixed;
 remove_action( 'init', array( $hookex_mixed, 'init1' ) );
 remove_action( 'init', array( 'Hookex_Mixed_Class', 'init2' ) );


### PR DESCRIPTION
Several updates here to documentation, [comment syntax](https://make.wordpress.org/core/handbook/inline-documentation-standards/php-documentation-standards/#5-2-multi-line-comments), and a helper function for removing anonymous object filters.
